### PR TITLE
Revert "chore(deps): bump @mantine/next from 4.2.8 to 4.2.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@mantine/core": "^4.2.8",
         "@mantine/hooks": "^4.2.4",
-        "@mantine/next": "^4.2.9",
+        "@mantine/next": "^4.2.8",
         "@supabase/supabase-js": "^1.35.3",
         "iron-session": "^6.1.3",
         "isomorphic-dompurify": "^0.19.0",
@@ -380,11 +380,11 @@
       }
     },
     "node_modules/@mantine/next": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/next/-/next-4.2.9.tgz",
-      "integrity": "sha512-avbxQeR9EerSHJ3HOg7rPAyBUoJ3/ifvYifyP/Sd6ap3hGzF1a/NN4tSRjoRmz1jTyAdmKIhL0k0alwi1OqA2A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@mantine/next/-/next-4.2.8.tgz",
+      "integrity": "sha512-EEKQ1HtP5MeCtx0Y8BM5BI53zvSwjaCsfoDerbjSWK9wan5UWcmkV5ZcYsBjbJMnuAKW0PoZaY1SwFd0uunmdQ==",
       "dependencies": {
-        "@mantine/ssr": "4.2.9"
+        "@mantine/ssr": "4.2.8"
       },
       "peerDependencies": {
         "next": "*",
@@ -393,35 +393,18 @@
       }
     },
     "node_modules/@mantine/ssr": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/ssr/-/ssr-4.2.9.tgz",
-      "integrity": "sha512-6B5R8ELRR+GQaXdnUUoSlZXEA5DiG4Pp91EOJTU+UYnieQ+gdLISp2HmYAvKMpETViOciBou6r8j2hH74tls4g==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@mantine/ssr/-/ssr-4.2.8.tgz",
+      "integrity": "sha512-DCna1pXc3F3Bqbdf+K4wNvCBVSbLuIv2YiyKmE/Yw9Yhod34lVueXIDgkIhSOSwhjBkImqJDaPGxmme1M/XWCQ==",
       "dependencies": {
         "@emotion/cache": "11.7.1",
         "@emotion/react": "11.7.1",
         "@emotion/serialize": "1.0.2",
         "@emotion/server": "11.4.0",
         "@emotion/utils": "1.0.0",
-        "@mantine/styles": "4.2.9",
+        "@mantine/styles": "4.2.8",
         "csstype": "3.0.9",
         "html-react-parser": "1.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@mantine/ssr/node_modules/@mantine/styles": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.9.tgz",
-      "integrity": "sha512-UT5m1412N20HPl+Mg2zTN7gP34J1GIa3o7eQ+fHThAQkAMm/vBehzX8nkbdxwyYkwuu6+/4kizcbM/Op4jMI3g==",
-      "dependencies": {
-        "@emotion/cache": "11.7.1",
-        "@emotion/react": "11.7.1",
-        "@emotion/serialize": "1.0.2",
-        "@emotion/utils": "1.0.0",
-        "clsx": "^1.1.1",
-        "csstype": "3.0.9"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -4202,12 +4185,12 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/through2": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
+      "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "dependencies": {
         "readable-stream": "~1.0.17",
         "xtend": "~2.1.1"
@@ -4403,7 +4386,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -4587,7 +4570,7 @@
     "node_modules/xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -4903,41 +4886,28 @@
       "requires": {}
     },
     "@mantine/next": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/next/-/next-4.2.9.tgz",
-      "integrity": "sha512-avbxQeR9EerSHJ3HOg7rPAyBUoJ3/ifvYifyP/Sd6ap3hGzF1a/NN4tSRjoRmz1jTyAdmKIhL0k0alwi1OqA2A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@mantine/next/-/next-4.2.8.tgz",
+      "integrity": "sha512-EEKQ1HtP5MeCtx0Y8BM5BI53zvSwjaCsfoDerbjSWK9wan5UWcmkV5ZcYsBjbJMnuAKW0PoZaY1SwFd0uunmdQ==",
       "requires": {
-        "@mantine/ssr": "4.2.9"
+        "@mantine/ssr": "4.2.8"
       }
     },
     "@mantine/ssr": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@mantine/ssr/-/ssr-4.2.9.tgz",
-      "integrity": "sha512-6B5R8ELRR+GQaXdnUUoSlZXEA5DiG4Pp91EOJTU+UYnieQ+gdLISp2HmYAvKMpETViOciBou6r8j2hH74tls4g==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@mantine/ssr/-/ssr-4.2.8.tgz",
+      "integrity": "sha512-DCna1pXc3F3Bqbdf+K4wNvCBVSbLuIv2YiyKmE/Yw9Yhod34lVueXIDgkIhSOSwhjBkImqJDaPGxmme1M/XWCQ==",
       "requires": {
         "@emotion/cache": "11.7.1",
         "@emotion/react": "11.7.1",
         "@emotion/serialize": "1.0.2",
         "@emotion/server": "11.4.0",
         "@emotion/utils": "1.0.0",
-        "@mantine/styles": "4.2.9",
+        "@mantine/styles": "4.2.8",
         "csstype": "3.0.9",
         "html-react-parser": "1.3.0"
       },
       "dependencies": {
-        "@mantine/styles": {
-          "version": "4.2.9",
-          "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.9.tgz",
-          "integrity": "sha512-UT5m1412N20HPl+Mg2zTN7gP34J1GIa3o7eQ+fHThAQkAMm/vBehzX8nkbdxwyYkwuu6+/4kizcbM/Op4jMI3g==",
-          "requires": {
-            "@emotion/cache": "11.7.1",
-            "@emotion/react": "11.7.1",
-            "@emotion/serialize": "1.0.2",
-            "@emotion/utils": "1.0.0",
-            "clsx": "^1.1.1",
-            "csstype": "3.0.9"
-          }
-        },
         "html-react-parser": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.3.0.tgz",
@@ -7700,12 +7670,12 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
+      "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "requires": {
         "readable-stream": "~1.0.17",
         "xtend": "~2.1.1"
@@ -7850,7 +7820,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -7989,7 +7959,7 @@
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "requires": {
         "object-keys": "~0.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@mantine/core": "^4.2.8",
     "@mantine/hooks": "^4.2.4",
-    "@mantine/next": "^4.2.9",
+    "@mantine/next": "^4.2.8",
     "@supabase/supabase-js": "^1.35.3",
     "iron-session": "^6.1.3",
     "isomorphic-dompurify": "^0.19.0",


### PR DESCRIPTION
Reverts MystPi/scratch-tutorials#18. For some reason it was producing FOUC (flash of unstyled content) again.